### PR TITLE
`apply` for functions evaluates (chronologically) left-to-right

### DIFF
--- a/src/FSharpPlus/Control/Applicative.fs
+++ b/src/FSharpPlus/Control/Applicative.fs
@@ -25,7 +25,7 @@ type Apply =
     static member        ``<*>`` (f: IEnumerator<_>   , x: IEnumerator<'T>      , [<Optional>]_output: IEnumerator<'U>      , [<Optional>]_mthd: Apply) = Enumerator.map2 id f x : IEnumerator<'U>
     static member        ``<*>`` (f: list<_>          , x: list<'T>             , [<Optional>]_output: list<'U>             , [<Optional>]_mthd: Apply) = List.apply f x                               : list<'U>
     static member        ``<*>`` (f: _ []             , x: 'T []                , [<Optional>]_output: 'U []                , [<Optional>]_mthd: Apply) = Array.apply f x                              : 'U []
-    static member        ``<*>`` (f: 'r -> _          , g: _ -> 'T              , [<Optional>]_output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> f x (g x)                           : 'U
+    static member        ``<*>`` (f: 'r -> _          , g: _ -> 'T              , [<Optional>]_output:  'r -> 'U            , [<Optional>]_mthd: Apply) = fun x -> let f' = f x in f' (g x)            : 'U
     static member inline ``<*>`` ((a: 'Monoid, f)     , (b: 'Monoid, x: 'T)     , [<Optional>]_output: 'Monoid * 'U         , [<Optional>]_mthd: Apply) = (Plus.Invoke a b, f x)                       : 'Monoid *'U
     static member        ``<*>`` (f: Task<_>          , x: Task<'T>             , [<Optional>]_output: Task<'U>             , [<Optional>]_mthd: Apply) = Task.apply   f x : Task<'U>
     static member        ``<*>`` (f: Async<_>         , x: Async<'T>            , [<Optional>]_output: Async<'U>            , [<Optional>]_mthd: Apply) = Async.apply  f x : Async<'U>

--- a/tests/FSharpPlus.Tests/General.fs
+++ b/tests/FSharpPlus.Tests/General.fs
@@ -1544,10 +1544,18 @@ module Applicative =
         let run (ZipList x) = x
         let run' (ZipList' x) = x
 
+
         // Test Applicative (functions)
+        let fn = 
+            let mutable x = 0
+            fun () -> 
+                x <- x + 1
+                x
         let res607 = map (+) ( (*) 100 ) 6 7
         let res606 = ( (+) <*>  (*) 100 ) 6
         let res508 = (map (+) ((+) 3 ) <*> (*) 100) 5
+        let res123 = (map tuple3 fn <*> fn <*> fn) ()
+        let res456 = (sequence [fn; fn; fn] : unit -> int list) ()
 
         // Test Applicative (ZipList)
         let res9n5  = map ((+) 1) (ZipList [8;4])
@@ -1558,6 +1566,8 @@ module Applicative =
         Assert.AreEqual (607, res607)
         Assert.AreEqual (606, res606)
         Assert.AreEqual (508, res508)
+        Assert.AreEqual ((1,2,3), res123)
+        Assert.AreEqual ([4;5;6], res456)
         Assert.AreEqual (toList (run res9n5), toList (run' res9n5'))
 
     let testLift2 () =


### PR DESCRIPTION
...in case the function contains side-effects
